### PR TITLE
MICC-247 remove header row skip from evaluation eval_scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 docker/templates/task1-binary/sample-test-data/predictions/*.*
 docker/templates/task2-parts/sample-test-data/predictions/*.*
+eval_scripts/data

--- a/eval_scripts/evaluate-task1-binary.py
+++ b/eval_scripts/evaluate-task1-binary.py
@@ -100,9 +100,6 @@ metrics_list = []
 
 with open(test_csv_path, 'r') as file:
     reader = csv.reader(file)
-    # skip the header row
-    next(reader)
-    
     # loop through each row in the CSV file
     for row in reader:
         image_name = row[0]  

--- a/eval_scripts/evaluate-task2-parts.py
+++ b/eval_scripts/evaluate-task2-parts.py
@@ -102,7 +102,6 @@ metrics_list_dict = {
 # loop through images in directory
 with open(test_csv_path, 'r') as file:
     reader = csv.reader(file)
-    next(reader)  # skip the header row
     for row in reader:
         image_name = row[0]
         image_hash = image_name 


### PR DESCRIPTION
Removed lines that read the first line of the CSV file from the two evaluation scripts.